### PR TITLE
Use length prefixing for auth messages

### DIFF
--- a/authenticate.py
+++ b/authenticate.py
@@ -1,9 +1,10 @@
 from enum import Enum
 import socket
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 import json
 import os
 import base64
+import struct
 
 from OpenSSL import crypto
 from dotenv import load_dotenv
@@ -63,7 +64,7 @@ class Authenication:
             }
 
             # print(message)
-            self.stream.send(json.dumps(message).encode("utf-8"))
+            self._send_message(message)
             print("Authenticated")
         except KeyError:
             print("Private Key not set in environemt variable")
@@ -86,13 +87,12 @@ class Authenication:
 
     def verify(self) -> bool:
         message = {"NewModel": {"email": self.email, "model_name": self.model_name}}
-        self.stream.send(json.dumps(message).encode("utf-8"))
+        self._send_message(message)
 
         while True:
             # Read some data
-            data = json.loads(self.stream.recv(1024))
-
-            # print("data: {}".format(data))
+            data = self._read_message() 
+            print("data: {}".format(data))
 
             try:
                 variant, data = self.parse_message(data)
@@ -127,6 +127,35 @@ class Authenication:
         with path.open('w') as f:
 
             f.write(json.dumps(json_contents))
+
+    def _read_message(self) -> Dict:
+        size_bytes = self.stream.recv(4)
+        # print("size_bytes: {}".format(size_bytes))
+
+        size = struct.unpack(">I", size_bytes)[0]
+
+        if size > 4096:
+            remaining_size = size
+            buffer = []
+
+            while remaining_size > 0:
+                chunk = self.stream.recv(4096)
+                buffer.extend(chunk)
+
+                remaining_size -= 4096
+
+            return json.loads(buffer)
+
+        return json.loads(self.stream.recv(size))
+
+    def _send_message(self, message: Union[Dict, str], dump=True):
+        data = json.dumps(message) if dump else message
+        data = data.encode("utf-8")
+
+        length = (len(data)).to_bytes(4, byteorder="big")
+        # print("length: {}".format(length))
+
+        self.stream.send(length + data)
                 
 def main():
 

--- a/sybl/client/sybl_client.py
+++ b/sybl/client/sybl_client.py
@@ -167,7 +167,7 @@ class Sybl:
             predict_pd = pd.read_csv(io.StringIO(predict))
 
             predictions = self.callback(train_pd, predict_pd)
-            message = {"Predictions": predictions.to_string()}
+            message = {"Predictions": predictions.to_csv(index=False)}
             self._send_message(message)
             self._state = State.HEARTBEAT
 


### PR DESCRIPTION
Use length prefixing when sending authorisation methods to the DCL and
convert the predictions to a CSV document correctly without the index
column.