### PR TITLE
Test/process job

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyOpenSSL==20.0.0
 pytest==6.2.1
 python-dotenv==0.15.0
 xdg==5.0.1
+numpy==1.20.1

--- a/sybl/client/sybl_client.py
+++ b/sybl/client/sybl_client.py
@@ -258,7 +258,7 @@ class Sybl:
     ) -> Tuple[pd.DataFrame, pd.DataFrame, List]:
         if "record_id" in train.columns:
             # Take record ids from training set
-            train = train.drop(["record_id"], axis=1)
+            train.drop(["record_id"], axis=1, inplace=True)
             logger.debug("Training Data: %s", train.head())
 
             # Take record ids from predict set and store for later

--- a/sybl/client/sybl_client.py
+++ b/sybl/client/sybl_client.py
@@ -244,7 +244,7 @@ class Sybl:
         # Attatch record ids onto predictions
         predictions["record_id"] = predict_rids
         cols = predictions.columns.tolist()
-        cols = cols[-1:] + cols[:-1]
+        cols = cols.insert(0, cols.pop())
         predictions = predictions[cols]
 
         assert len(predictions.index) == len(predict_pd.index)

--- a/sybl/client/sybl_client.py
+++ b/sybl/client/sybl_client.py
@@ -239,8 +239,6 @@ class Sybl:
 
         predictions = self.callback(train_pd, predict_pd)
 
-        logger.debug("PIDS: %s", predict_rids)
-
         logger.debug("Predictions: %s", predictions.head())
 
         # Attatch record ids onto predictions
@@ -253,7 +251,6 @@ class Sybl:
 
         message = {"Predictions": predictions.to_csv(index=False)}
         self._send_message(message)
-        logger.info("Sent message")
         self._state = State.HEARTBEAT
 
     def _prepare_datasets(

--- a/sybl/client/sybl_client.py
+++ b/sybl/client/sybl_client.py
@@ -265,7 +265,7 @@ class Sybl:
         # Attatch record ids onto predictions
         predictions["record_id"] = predict_rids
         cols = predictions.columns.tolist()
-        cols = cols[-1:] + cols[:-1]
+        cols.insert(0, cols.pop())
         predictions = predictions[cols]
 
         assert len(predictions.index) == len(predict_pd.index)

--- a/sybl/client/sybl_client.py
+++ b/sybl/client/sybl_client.py
@@ -244,7 +244,7 @@ class Sybl:
         # Attatch record ids onto predictions
         predictions["record_id"] = predict_rids
         cols = predictions.columns.tolist()
-        cols = cols.insert(0, cols.pop())
+        cols = cols[-1:] + cols[:-1]
         predictions = predictions[cols]
 
         assert len(predictions.index) == len(predict_pd.index)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -281,8 +281,7 @@ def test_process_job(sybl_instance, valid_dataset):
     assert sybl_instance._send_message.called
 
     cols = predictions.columns.tolist()
-    cols = cols[-1:] + cols[:-1]
-    predictions = predictions[cols]
+    predictions = predictions[cols[-1:] + cols[:-1]]
 
     sybl_instance._send_message.assert_called_with(
         {"Predictions": predictions.to_csv(index=False)}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ and correct responses to messages sent from the DCL
 import os
 import tempfile
 from unittest.mock import Mock
+import pandas as pd
 
 import pytest
 
@@ -132,7 +133,7 @@ def test_reject_bad_config(sybl_instance):
         sybl_instance.load_config(bad_config)
 
 
-def test_heartbeat(sybl_instance):
+def test_message_control(sybl_instance):
 
     responses = [
         ({"Alive": ""}, State.HEARTBEAT),
@@ -143,7 +144,7 @@ def test_heartbeat(sybl_instance):
     for response in responses:
         sybl_instance._read_message = Mock(return_value=response[0])
 
-        sybl_instance._heartbeat()
+        sybl_instance._message_control()
         assert sybl_instance._state == response[1]
 
 
@@ -217,3 +218,12 @@ def test_file_does_not_exist(sybl_instance):
 
     with pytest.raises(FileNotFoundError):
         load_access_token(sybl_instance.email, sybl_instance.model_name)
+
+def test_remove_record_ids(sybl_instance):
+    train = pd.DataFrame([1, "Data1"],[2, "Data2"], columns =['record_id', 'col1'])
+    prediction = pd.DataFrame([3, "Data3"],[4, "Data4"], columns =['record_id', 'col1'])
+    initial_pids = prediction[["record_id"]]
+    train, prediction, predict_rids = sybl_instance._prepare_datasets(train, prediction)
+
+    assert ("record_id" not in list(train.columns)) and ("record_id" not in list(prediction.columns))
+    assert predict_rids == initial_pids

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -220,8 +220,8 @@ def test_file_does_not_exist(sybl_instance):
         load_access_token(sybl_instance.email, sybl_instance.model_name)
 
 def test_remove_record_ids(sybl_instance):
-    train = pd.DataFrame([1, "Data1"],[2, "Data2"], columns =['record_id', 'col1'])
-    prediction = pd.DataFrame([3, "Data3"],[4, "Data4"], columns =['record_id', 'col1'])
+    train = pd.DataFrame({'record_id':[1,2],'col1':["Data1", "Data2"]})
+    prediction = pd.DataFrame({'record_id':[3,4],'col1':["Data3", "Data4"]})
     initial_pids = prediction[["record_id"]]
     train, prediction, predict_rids = sybl_instance._prepare_datasets(train, prediction)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,9 +6,10 @@ and correct responses to messages sent from the DCL
 import os
 import tempfile
 from unittest.mock import Mock
+import io  # type: ignore
+
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
-import io  # type: ignore
 
 import pytest
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,7 @@ import pytest
 from mocket.mocket import mocketize  # type: ignore
 
 from sybl.client import Sybl
-from sybl.client.sybl_client import State, load_access_token
+from sybl.client.sybl_client import State, load_access_token, prepare_datasets
 from sybl.authenticate import Authentication
 
 # pylint: disable=protected-access
@@ -249,7 +249,7 @@ def test_prepare_dataset(sybl_instance):
     train = pd.DataFrame({"record_id": [1, 2], "col1": ["Data1", "Data2"]})
     prediction = pd.DataFrame({"record_id": [3, 4], "col1": ["Data3", "Data4"]})
     initial_pids = prediction["record_id"].tolist()
-    train, prediction, predict_rids = sybl_instance._prepare_datasets(train, prediction)
+    train, prediction, predict_rids = prepare_datasets(train, prediction)
 
     assert ("record_id" not in list(train.columns)) and (
         "record_id" not in list(prediction.columns)
@@ -297,4 +297,4 @@ def test_bad_data_prepare_data(sybl_instance, invalid_dataset):
     prediction = pd.read_csv(io.StringIO(invalid_dataset["Dataset"]["predict"]))
 
     with pytest.raises(AttributeError):
-        sybl_instance._prepare_datasets(train, prediction)
+        prepare_datasets(train, prediction)


### PR DESCRIPTION
Adds some tests for `_process_job`, tidies up parts and creates new function focused on removing `record_id`s from datasets and returning them to make it more testable.