### PR TITLE
Add password verification on model creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ import pandas as pd  # type: ignore
 
 from sybl.client import Sybl
 from sybl.client import JobConfig
-import pandas as pd
 
 sybl = Sybl()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -210,7 +210,7 @@ def test_load_access_token(sybl_instance):
 
     with tempfile.TemporaryDirectory() as directory:
         os.environ["XDG_DATA_HOME"] = directory
-        instance = Authentication("model@email", "Test Model")
+        instance = Authentication("model@email", "password", "Test Model")
         instance.access_token = ""
         instance.model_id = "2344423"
         instance.save_access_tokens()
@@ -228,7 +228,7 @@ def test_bad_model_name(sybl_instance):
 
     with tempfile.TemporaryDirectory() as directory:
         os.environ["XDG_DATA_HOME"] = directory
-        instance = Authentication("model@email", "Test Model")
+        instance = Authentication("model@email", "password", "Test Model")
         instance.access_token = ""
         instance.model_id = "2344423"
         instance.save_access_tokens()


### PR DESCRIPTION
When users try and create models, send their password alongside it for better verification. This constitutes the Mallus side of FreddieBrown/dodona#304, which implements this functionality into the rest of the backend.
