### PR TITLE
feat: use coloured logging output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest==6.2.1
 python-dotenv==0.15.0
 xdg==5.0.1
 numpy==1.20.1
+zenlog==1.1


### PR DESCRIPTION
Swap to `zenlog` for basic coloured logging output. This is useful to show clients error messages in red, which stand out better among stack traces.
