### PR TITLE
fix: find the correct `.env` file

### DIFF
--- a/sybl/authenticate.py
+++ b/sybl/authenticate.py
@@ -25,7 +25,10 @@ from dotenv import load_dotenv, find_dotenv
 from xdg import xdg_data_home
 from zenlog import log  # type: ignore
 
-load_dotenv(find_dotenv())
+
+env_path = os.path.join(Path().absolute(), ".env")
+log.debug(f"Loading the `.env` file at: {env_path}")
+load_dotenv(env_path)
 
 
 def sign_challenge(challenge: bytes, private_key: str) -> bytes:


### PR DESCRIPTION
When searching for the `.env` file, `find_dotenv()` seems to use the directory of `mallus` itself instead of the current directory when installed locally. This explains why it finds a `.env` file, as it is looking for the one I have within `mallus` itself.

Instead, use `pathlib` to get the current execution directory and use the `.env` file there instead.
