### PR TITLE
Fix edge case in models

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,8 +14,10 @@ sybl = Sybl()
 
 def ohe(dataset):
     categorical = dataset.select_dtypes("object")
-    encoded = pd.get_dummies(categorical[categorical.columns])
-    return pd.concat([dataset, encoded], axis=1).drop(categorical, axis=1)
+    if list(categorical.columns) != []:
+        encoded = pd.get_dummies(categorical[categorical.columns])
+        return pd.concat([dataset, encoded], axis=1).drop(categorical, axis=1)
+    return dataset
 
 
 def callback(train, predict, job_config):

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ sybl = Sybl()
 
 def ohe(dataset):
     categorical = dataset.select_dtypes("object")
-    if list(categorical.columns) != []:
+    if not categorical.empty:
         encoded = pd.get_dummies(categorical[categorical.columns])
         return pd.concat([dataset, encoded], axis=1).drop(categorical, axis=1)
     return dataset


### PR DESCRIPTION
Models crash when given data with only numerical attributes because Pandas crashes when attempting to OHE an empty dataframe (the subset of the dataframe with categorical attributes). This PR ensures the OHE is only performed when there are categorical attributes to encode.