### PR TITLE
docs: update the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # Mallus
-Python Module for clients to connect to the Sybl service
+
+`mallus` is a Python module that allows clients to connect to the Sybl service.
+
+## Requirements
+
+The requirements for `mallus` can be installed as follows:
+```bash
+pip install -r requirements.txt
+```
+
+Alternatively, you can install `mallus` from the test variant of PyPI:
+```bash
+pip install -i https://test.pypi.org/simple/ syblmallus --extra-index-url
+https://pypi.org/simple/
+```
+
+## Getting Started
+
+To begin working with `mallus` and running models as a client on Sybl, you
+should first have both the `api-server` and `dcl` binaries executing from
+`dodona`. Further instructions can then be found in the `guides/` directory in
+the `dodona` repository, specifically the `become_a_client.md` and
+`register_a_model.md` guides.


### PR DESCRIPTION
Update the README file to work as a basic installation guide, showing how to install from both source and TestPyPI. Reference the guides that will be added to `dodona` in FreddieBrown/dodona#478 as a way of getting started with the system.
